### PR TITLE
Update Norton-QuickCheck.html to fix font rendering

### DIFF
--- a/slides/Norton-QuickCheck.html
+++ b/slides/Norton-QuickCheck.html
@@ -7,7 +7,7 @@
     <meta name="author" content="Joseph Wayne Norton">
     <meta name="generator" content="AsciiDoc 8.6.8, dzslides backend. Code highlighting courtesy of highlight.js.">
     <meta name="presdate" content="Jul 9, 2013">
-    <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Yanone+Kaffeesatz:400,700,200,300&amp;family=Cedarville+Cursive">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Yanone+Kaffeesatz:400,700,200,300&amp;family=Cedarville+Cursive">
     <style>
 /*
 Monokai style - ported by Luigi Maselli - http://grigio.org


### PR DESCRIPTION
Modern browsers now disallow mixed HTTP/HTTPS contents for security reasons.
As a result, the Google font is blocked and the slides are misrendered with https://github.com/htmlpreview/htmlpreview.github.com :
https://htmlpreview.github.io/?https://raw.githubusercontent.com/strangeloop/lambdajam2013/master/slides/Norton-QuickCheck.html
Switching to an HTTPS-request for the font fixes the issue.